### PR TITLE
Added CNAME file to host website from openc2.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+openc2.org


### PR DESCRIPTION
Added CNAME file to host website from openc2.org instead of https://openc2-org.github.io/openc2-org.github.io