### PR TITLE
Add summer publishing activity to News

### DIFF
--- a/news.html
+++ b/news.html
@@ -13,8 +13,21 @@ permalink: /news.html
         <div class="content">
           <h6>August 17, 2021</h6>
           <p>
+            <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00021.html">
+              OASIS Publishes CSD01 of the OpenC2 Language Specification, v1.1</a>.
+              <br>
+            The Language Specification is the foundation document defining the OpenC2 language. 
+            Version 1.1 of the Language Specification will address changes identified since the 
+            November 2019 publication of v1.0, CSD02.
+          </p>
+        </div>
+      </div>     
+      <div class="timecard"  data-aos="fade-up">
+        <div class="content">
+          <h6>August 17, 2021</h6>
+          <p>
             <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00009.html">
-              OASIS Publishes CSD01 of the Actuator Profile for Packet Filtering</a>.
+              OASIS Publishes CSD01 of the Actuator Profile for Packet Filtering, v1.0</a>.
               <br>
             The Packet Filtering AP will combine stateless and stateful packet filtering 
             under a single AP, and make provisions for use in cloud environments.

--- a/news.html
+++ b/news.html
@@ -24,6 +24,18 @@ permalink: /news.html
       </div>     
       <div class="timecard"  data-aos="fade-up">
         <div class="content">
+          <h6>August 4, 2021</h6>
+          <p>
+            <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00003.html">
+              Public review of the JADN Committee Specification Draft 02 completed</a>.
+              <br>
+            The second public review of the JADN specification was conducted between June 29th and July 18th, 2021.
+            A single comment was received, and the CRM is attached to the linked message.
+          </p>
+        </div>
+      </div>     
+      <div class="timecard"  data-aos="fade-up">
+        <div class="content">
           <h6>August 17, 2021</h6>
           <p>
             <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00009.html">

--- a/news.html
+++ b/news.html
@@ -65,18 +65,6 @@ permalink: /news.html
       </div>     
       <div class="timecard"  data-aos="fade-up">
         <div class="content">
-          <h6>August 4, 2021</h6>
-          <p>
-            <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00003.html">
-              Public review of the JADN Committee Specification Draft 02 completed</a>.
-              <br>
-            The second public review of the JADN specification was conducted between June 29th and July 18th, 2021.
-            A single comment was received, and the CRM is attached to the linked message.
-          </p>
-        </div>
-      </div>     
-      <div class="timecard"  data-aos="fade-up">
-        <div class="content">
           <h6>June 24, 2021</h6>
           <p>
             <a rel="noopener noreferrer" target="_blank" href="https://youtu.be/XTpMQaANg6A">

--- a/news.html
+++ b/news.html
@@ -11,7 +11,7 @@ permalink: /news.html
 
       <div class="timecard"  data-aos="fade-up">
         <div class="content">
-          <h6>August 17, 2021</h6>
+          <h6>August 30, 2021</h6>
           <p>
             <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00021.html">
               OASIS Publishes CSD01 of the OpenC2 Language Specification, v1.1</a>.
@@ -24,18 +24,6 @@ permalink: /news.html
       </div>     
       <div class="timecard"  data-aos="fade-up">
         <div class="content">
-          <h6>August 4, 2021</h6>
-          <p>
-            <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00003.html">
-              Public review of the JADN Committee Specification Draft 02 completed</a>.
-              <br>
-            The second public review of the JADN specification was conducted between June 29th and July 18th, 2021.
-            A single comment was received, and the CRM is attached to the linked message.
-          </p>
-        </div>
-      </div>     
-      <div class="timecard"  data-aos="fade-up">
-        <div class="content">
           <h6>August 17, 2021</h6>
           <p>
             <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00009.html">
@@ -43,6 +31,18 @@ permalink: /news.html
               <br>
             The Packet Filtering AP will combine stateless and stateful packet filtering 
             under a single AP, and make provisions for use in cloud environments.
+          </p>
+        </div>
+      </div>     
+      <div class="timecard"  data-aos="fade-up">
+        <div class="content">
+          <h6>August 4, 2021</h6>
+          <p>
+            <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00003.html">
+              Public review of the JADN Committee Specification Draft 02 completed</a>.
+              <br>
+            The second public review of the JADN specification was conducted between June 29th and July 18th, 2021.
+            A single comment was received, and the CRM is attached to the linked message.
           </p>
         </div>
       </div>     

--- a/news.html
+++ b/news.html
@@ -11,6 +11,18 @@ permalink: /news.html
 
       <div class="timecard"  data-aos="fade-up">
         <div class="content">
+          <h6>August 17, 2021</h6>
+          <p>
+            <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00009.html">
+              OASIS Publishes CSD01 of the Actuator Profile for Packet Filtering</a>.
+              <br>
+            The Packet Filtering AP will combine stateless and stateful packet filtering 
+            under a single AP, and make provisions for use in cloud environments.
+          </p>
+        </div>
+      </div>     
+      <div class="timecard"  data-aos="fade-up">
+        <div class="content">
           <h6>June 24, 2021</h6>
           <p>
             <a rel="noopener noreferrer" target="_blank" href="https://youtu.be/XTpMQaANg6A">

--- a/news.html
+++ b/news.html
@@ -30,6 +30,21 @@ permalink: /news.html
             <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00021.html">
               OASIS Publishes CSD01 of the OpenC2 Language Specification, v1.1</a>.
               <br>
+              JSON Abstract Data Notation (JADN) is a UML-based information modeling language that defines data structure 
+              independently of data format. Information models are used to define and generate physical data models, 
+              validate information instances, and enable lossless translation across data formats. A JADN specification 
+              consists of two parts: type definitions that comprise the information model, and serialization rules that 
+              define how information instances are represented as data.
+          </p>
+        </div>
+      </div>     
+      <div class="timecard"  data-aos="fade-up">
+        <div class="content">
+          <h6>August 24, 2021</h6>
+          <p>
+            <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00019.html">
+              OASIS Publishes CS01 of the JSON Abstract Data Notation (JADN) Specification, v1.0</a>.
+              <br>
             The Language Specification is the foundation document defining the OpenC2 language. 
             Version 1.1 of the Language Specification will address changes identified since the 
             November 2019 publication of v1.0, CSD02.

--- a/news.html
+++ b/news.html
@@ -30,11 +30,9 @@ permalink: /news.html
             <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00021.html">
               OASIS Publishes CSD01 of the OpenC2 Language Specification, v1.1</a>.
               <br>
-              JSON Abstract Data Notation (JADN) is a UML-based information modeling language that defines data structure 
-              independently of data format. Information models are used to define and generate physical data models, 
-              validate information instances, and enable lossless translation across data formats. A JADN specification 
-              consists of two parts: type definitions that comprise the information model, and serialization rules that 
-              define how information instances are represented as data.
+            The Language Specification is the foundation document defining the OpenC2 language. 
+            Version 1.1 of the Language Specification will address changes identified since the 
+            November 2019 publication of v1.0, CSD02.
           </p>
         </div>
       </div>     
@@ -45,9 +43,11 @@ permalink: /news.html
             <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00019.html">
               OASIS Publishes CS01 of the JSON Abstract Data Notation (JADN) Specification, v1.0</a>.
               <br>
-            The Language Specification is the foundation document defining the OpenC2 language. 
-            Version 1.1 of the Language Specification will address changes identified since the 
-            November 2019 publication of v1.0, CSD02.
+              JSON Abstract Data Notation (JADN) is a UML-based information modeling language that defines data structure 
+              independently of data format. Information models are used to define and generate physical data models, 
+              validate information instances, and enable lossless translation across data formats. A JADN specification 
+              consists of two parts: type definitions that comprise the information model, and serialization rules that 
+              define how information instances are represented as data.
           </p>
         </div>
       </div>     

--- a/news.html
+++ b/news.html
@@ -13,6 +13,20 @@ permalink: /news.html
         <div class="content">
           <h6>August 30, 2021</h6>
           <p>
+            <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00022.html">
+              OASIS Announces Public Review of the MQTT Transfer Specification, v1.0</a>.
+              <br>
+            OpenC2 transfer specifications describe how to use standard protocols to transfer OpenC2 messages. 
+            The MQTT Transfer Specification describes how to use 
+            <a rel="noopener noreferrer" target="_blank" href="https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html">
+              MQTT v5.0</a> in support of OpenC2 messaging.
+          </p>
+        </div>
+      </div>     
+      <div class="timecard"  data-aos="fade-up">
+        <div class="content">
+          <h6>August 30, 2021</h6>
+          <p>
             <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202108/msg00021.html">
               OASIS Publishes CSD01 of the OpenC2 Language Specification, v1.1</a>.
               <br>


### PR DESCRIPTION
This PR adds publishing activities from June - August to the In The News page, specifically (reverse order):

- Public review of MQTT Transfer Spec
- Publication of LS v1.1, CSD01
- Publication of JADN Spec, v1.0, CS01
- Publication of the PF AP, v1.0, CSD01
- Completion of the JADN Spec public review

You can preview the published result at https://dlemire60.github.io/openc2-org.github.io/news.html

I reviewed the TC mail list archive back through April 2021 to identify publication events to add.