### PR TITLE
Update "Join Us" page

### DIFF
--- a/joinus.html
+++ b/joinus.html
@@ -23,7 +23,7 @@ permalink: /joinus.html
           href="https://github.com/oasis-tcs?utf8=%E2%9C%93&q=openc2&type=&language=">OpenC2
           technical artifacts</a> (AKA <a rel="noopener
           noreferrer" target="_blank"
-          href="(https://www.oasis-open.org/policies-guidelines/oasis-defined-terms-2018-05-22/#dWorkProduct">Work
+          href="https://www.oasis-open.org/policies-guidelines/oasis-defined-terms-2018-05-22/#dWorkProduct">Work
           Products</a> under development are housed in GitHub.
         </p>
         <p>

--- a/joinus.html
+++ b/joinus.html
@@ -19,7 +19,7 @@ permalink: /joinus.html
           You can also get involved in the OASIS OpenC2 technical committee to contribute to the on-going development and evolution of the standards.
         </p>
         <p>
-          The following subcommittees are active in the OpenC2 TC:
+          The following subcommittees are active in the OpenC2    TC:
         </p>
         <ul>
           <li><a rel="noopener noreferrer" target="_blank" href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2-actuator">OpenC2 Actuator Profile Subcommittee</a> - <em>Defining actuator profiles, the OpenC2 message elements applicable to specific cyber defense functions.</em></li>

--- a/joinus.html
+++ b/joinus.html
@@ -14,13 +14,17 @@ permalink: /joinus.html
           technology development and integration are <a
           rel="noopener noreferrer" target="_blank"
           href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2">encouraged
-          to use</a> OpenC2 technical artifacts, language
-          specifications and actuator profiles.
+          to use</a> OpenC2 TC technical artifacts (e.g., the
+          language specification and actuator profiles) when
+          developing C2 capabilities for cyber-defense.
         </p>
         <p>
           <a rel="noopener noreferrer" target="_blank"
-          href="https://github.com/oasis-open?utf8=%E2%9C%93&q=openc2-&type=&language=">OpenC2
-          technical artifacts</a> are housed in GitHub.
+          href="https://github.com/oasis-tcs?utf8=%E2%9C%93&q=openc2&type=&language=">OpenC2
+          technical artifacts</a> (AKA <a rel="noopener
+          noreferrer" target="_blank"
+          href="(https://www.oasis-open.org/policies-guidelines/oasis-defined-terms-2018-05-22/#dWorkProduct">Work
+          Products</a> under development are housed in GitHub.
         </p>
         <p>
           You can also get involved in the OASIS OpenC2 technical
@@ -31,7 +35,7 @@ permalink: /joinus.html
         <ul>
           <li><em>Overarching documents:</em> describe the broad
           capabilities of OpenC2 and the approach to using it.
-          These are the Language Specification (published as
+          These are the Language Specification (published as an
           OASIS Committee Specification) and the OpenC2
           Architecture (work-in-progress).</li>
           <li><em>Actuator Profiles:</em>  these map the OpenC2
@@ -50,7 +54,7 @@ permalink: /joinus.html
           were created to develop the three types of documents.
           The TC has now consolidated its process to a combined
           weekly working meeting, but information about the
-          subcommittees is available at OASIS to preserver the
+          subcommittees is available at OASIS to preserve the
           history:
         </p>
         <ul>


### PR DESCRIPTION
The Join Us page needed updates:

- Provide info about new working process 
- Provide info about types of documents
- Correct GitHub link to point to TC repos rather than open repos
- Deprecate info about subcommittees
