### PR TITLE
Adjust link to open new tab in Slide 3

### DIFF
--- a/content/homepage/carousel/slide3.html
+++ b/content/homepage/carousel/slide3.html
@@ -4,7 +4,7 @@ Specifications!</h2>
 <p class="animate__animated animate__fadeInUp">OpenC2 is defined across a family of specifications, including our Language Specification, Actuator Profiles, and Transfer Specifications. Our <a rel="noopener noreferrer" href="{{ site.baseurl }}/specifications.html">Specifications</a> page lists our published specifications. For more detail, see the <a rel="noopener noreferrer" href="{{ site.baseurl }}/pubhist.html">Publication History</a>. 
 </p>
 
-<p>We also have a <a rel="noopener noreferrer" href="https://github.com/oasis-tcs/openc2-tc-ops/blob/main/oc2-companion.md">friendly guide</a> to how it all fits together
+<p>We also have a <a rel="noopener noreferrer" target="_blank" href="https://github.com/oasis-tcs/openc2-tc-ops/blob/main/oc2-companion.md">friendly guide</a> to how it all fits together
 </p>
 
 <a rel="noopener noreferrer" href="{{ site.baseurl}}/pubhist.html" class="btn-get-started animate__animated animate__fadeInUp scrollto">Read More</a>


### PR DESCRIPTION
The Friendly  Guide is on GitHub, so should open in new tab. Added target=... to the link to make that happen.