### PR TITLE
Recognize HTTPS v1.1 CS01 Publication

### DIFF
--- a/pubhist.html
+++ b/pubhist.html
@@ -494,7 +494,7 @@ permalink: /pubhist.html
                 rel="noopener noreferrer"
                 target="_blank"
                 href="https://docs.oasis-open.org/openc2/open-impl-https/v1.1/csd01/open-impl-https-v1.1-csd01.html"
-                >CSD 01</a
+                >CSD 01 (public review)</a
               >
             </td>
             <td data-label="Publication Date">15 September 2021</td>

--- a/pubhist.html
+++ b/pubhist.html
@@ -474,7 +474,19 @@ permalink: /pubhist.html
               >
             </td>
             <td data-label="Publication Date">8 September 2021</td>
+          </tr>
           <tr>
+            <td data-label="Version">v1.1</td>
+            <td data-label="Approval Level">
+              <a
+                rel="noopener noreferrer"
+                target="_blank"
+                href="https://docs.oasis-open.org/openc2/open-impl-https/v1.1/cs01/open-impl-https-v1.1-cs01.html"
+                >CS 01</a
+              >
+            </td>
+            <td data-label="Publication Date">30 November 2021</td>
+          </tr>
           <tr>
             <td data-label="Version">v1.1</td>
             <td data-label="Approval Level">

--- a/specifications.html
+++ b/specifications.html
@@ -29,8 +29,8 @@ permalink: /specifications.html
         </li>
         <li>
           <a rel="noopener noreferrer" target="_blank"
-            href="https://docs.oasis-open.org/openc2/open-impl-https/v1.0/cs01/open-impl-https-v1.0-cs01.html">Specification
-            for Transfer of OpenC2 Messages via HTTPS Version 1.0
+            href="https://docs.oasis-open.org/openc2/open-impl-https/v1.1/cs01/open-impl-https-v1.1-cs01.html">Specification
+            for Transfer of OpenC2 Messages via HTTPS Version 1.1 (replaces July 2019 v1.0)
           </a>
         </li>
         <li>


### PR DESCRIPTION
- Updated Specifications list to point to v1.1 CS01
- Add v1.1 CS01 to publication history for HTTPS Transfer Spec
- Add "(public review") note to v1.1 CS01 pub hist