### PR TITLE
Add recent  MQTT and HTTPS CS publications to news

### DIFF
--- a/news.html
+++ b/news.html
@@ -28,6 +28,45 @@ permalink: /news.html
           </p>
         </div>
       </div>
+
+      <div class="timecard"  data-aos="fade-up">
+        <div class="content">
+          <h6>December 1, 2021</h6>
+          <p>
+            <a rel="noopener noreferrer" target="_blank" href="https://www.oasis-open.org/2021/12/03/specification-for-transfer-of-openc2-messages-via-https-v1-1-from-openc2-tc-approved-as-a-committee-specification/">
+              OASIS Publishes CS01 of the OpenC2 HTTPS Transfer Specification, v1.1</a>.
+              <br>
+              HTTP over TLS is a widely deployed transfer
+              protocol that provides authenticated, ordered,
+              lossless delivery of uniquely-identified messages.
+              This document specifies the use of HTTP over TLS as
+              a transfer mechanism for OpenC2 Messages. This
+              specification replaces the July 2019 v.10 CS01, and
+              incorporates changes to OpenC2 message formatting
+              and other lessons learned through interoperability
+              testing.  A Testing conformance target is provided
+              to support interoperability testing without
+              security mechanisms. 
+          </p>
+        </div>
+      </div>
+
+      <div class="timecard"  data-aos="fade-up">
+        <div class="content">
+          <h6>December 1, 2021</h6>
+          <p>
+            <a rel="noopener noreferrer" target="_blank" href="https://www.oasis-open.org/2021/12/01/specification-for-transfer-of-openc2-messages-via-mqtt-v1-0-from-openc2-tc-approved-as-a-committee-specification/">
+              OASIS Publishes CS01 of the OpenC2 MQTT Transfer Specification, v1.0</a>.
+              <br>
+              OpenC2 transfer specifications describe how to use
+              standard protocols to transfer OpenC2 messages. The
+              MQTT Transfer Specification describes how to use
+            <a rel="noopener noreferrer" target="_blank" href="https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html">
+              MQTT v5.0</a> in support of OpenC2 messaging.
+          </p>
+        </div>
+      </div>
+
       <div class="timecard"  data-aos="fade-up">
         <div class="content">
           <h6>August 30, 2021</h6>


### PR DESCRIPTION
Add cards to the In The News page recognizing the publication of new transfer specifications