### PR TITLE
OpenC2.org update - carousel, pub history

### DIFF
--- a/content/homepage/carousel/slide4.html
+++ b/content/homepage/carousel/slide4.html
@@ -2,11 +2,11 @@
 Automation Workshop: 2 June 2022!</h2>
 
 <p class="animate__animated animate__fadeInUp">OpenC2 TC members
-and others will be participating in a <a rel="noopener
+and others participated in a <a rel="noopener
 noreferrer" target="_blank"
 href="http://www.cybersecurityautomationworkshop.org/">
 Cybersecurity Automation Workshop</a> plugfest event on June 2nd.
-Workshop participants will be testing use cases related to SBOM
+Workshop participants tested use cases related to SBOM
 retrieval, security <a rel="noopener noreferrer" target="_blank"
 href="https://github.com/opencybersecurityalliance/PACE">posture
 attribute collection</a>a, and other cyberssecurity automation

--- a/pubhist.html
+++ b/pubhist.html
@@ -255,6 +255,72 @@ permalink: /pubhist.html
       <br /><br />
     </div>
 
+<!--- Section for the Architecture Specifciation -->
+
+<div class="container" id='PF AP'>
+  <div class="section-title">
+    <h2>OpenC2 Architecture Specification</h2>
+    <p class="section-subtitle">
+      <i>Cyberattacks are increasingly sophisticated, less
+      expensive to execute, dynamic and automated. The provision
+      of cyber defense via statically configured products
+      operating in isolation is untenable. Standardized
+      interfaces, protocols and data models will facilitate the
+      integration of the functional blocks within a system and
+      between systems. Open Command and Control (OpenC2) is a
+      concise and extensible language to enable
+      machine-to-machine communications for purposes of command
+      and control of cyber defense components, subsystems and/or
+      systems in a manner that is agnostic of the underlying
+      products, technologies, transport mechanisms or other
+      aspects of the implementation. The Architecture
+      Specification describes the abstract architecture of OpenC2
+      to define a common understanding of the messages and
+      interactions for all bindings and serializations.
+      </i>
+    </p>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">Version</th>
+        <th scope="col">Approval Level</th>
+        <th scope="col">Publication Date</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td data-label="Version">v1.0 WIP</td>
+        <td data-label="Approval Level">
+          <a
+            rel="noopener noreferrer"
+            target="_blank"
+            href="https://github.com/oasis-tcs/openc2-oc2arch/blob/working/oc2arch-v1.0.md"
+            >Working Meeting: 11 May 2022</a
+          >
+        </td>
+        <td data-label="Publication Date">11 May 2022</td>
+      <tr>
+      <tr>
+        <td data-label="Version">v1.0</td>
+        <td data-label="Approval Level">
+          <a
+            rel="noopener noreferrer"
+            target="_blank"
+            href="https://docs.oasis-open.org/openc2/oc2arch/v1.0/csd01/oc2arch-v1.0-csd01.html"
+            >CSD 01</a
+          >
+        </td>
+        <td data-label="Publication Date">18 May 2022</td>
+      </tr>
+    </tbody>
+  </table>
+  <br /><br />
+</div>
+
+
+
 
 
     <div class="container" id="slpf AP">
@@ -438,6 +504,59 @@ permalink: /pubhist.html
       <br /><br />
     </div>
 
+<!--- Section for the Packet Filter AP -->
+
+<div class="container" id='PF AP'>
+  <div class="section-title">
+    <h2>OpenC2 Actuator Profile for Posture Attribute Collection (PAC)</h2>
+    <p class="section-subtitle">
+      <i> This specification defines an actuator profile to
+      automate collection of security posture attributes from
+      virtual and physical computing resources using OpenC2.
+      Security Posture Attribute Collection (PAC) supports
+      security automation by providing mechanisms to collect and
+      aggregate the configuration and status of network
+      components for use in situational awareness, security
+      posture evaluation, and response actions. This actuator
+      profile defines the OpenC2 Actions, Targets, Arguments, and
+      Specifiers along with conformance clauses to enable the
+      operation of OpenC2 Producers and Consumers in the context
+      of PAC. It covers identification of computing resources,
+      definition of security-relevant resource attributes, and
+      controlling the collection of those attributes using direct
+      pull or event-based push mechanisms.
+      </i>
+    </p>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">Version</th>
+        <th scope="col">Approval Level</th>
+        <th scope="col">Publication Date</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td data-label="Version">v1.0 WIP</td>
+        <td data-label="Approval Level">
+          <a
+            rel="noopener noreferrer"
+            target="_blank"
+            href="https://github.com/oasis-tcs/openc2-ap-pac/blob/working/ap-pac.md"
+            >Working Meeting: 18 May 2022</a
+          >
+        </td>
+        <td data-label="Publication Date">18 May 2022</td>
+      <tr>
+    </tbody>
+  </table>
+  <br /><br />
+</div>
+
+
+<!--- Section for the HTTPS Transfer Specification -->
 
 
 

--- a/pubhist.html
+++ b/pubhist.html
@@ -504,7 +504,7 @@ permalink: /pubhist.html
       <br /><br />
     </div>
 
-<!--- Section for the Packet Filter AP -->
+<!--- Section for the Posture Attribute Collection AP -->
 
 <div class="container" id='PF AP'>
   <div class="section-title">

--- a/pubhist.html
+++ b/pubhist.html
@@ -255,7 +255,7 @@ permalink: /pubhist.html
       <br /><br />
     </div>
 
-<!--- Section for the Architecture Specifciation -->
+<!--- Section for the Architecture Specification -->
 
 <div class="container" id='PF AP'>
   <div class="section-title">


### PR DESCRIPTION
- Change new carousel slide to refer to CAW in past tense
- Update publication history to add Architecture Spec (recent CSD), PAC AP (WIP)