### PR TITLE
In The News Update: January - June 2022

### DIFF
--- a/news.html
+++ b/news.html
@@ -11,6 +11,25 @@ permalink: /news.html
 
       <div class="timecard"  data-aos="fade-up">
         <div class="content">
+          <h6>April 28, 2022</h6>
+          <p>
+            <a rel="noopener noreferrer" target="_blank" href="https://www.linkedin.com/posts/vasileiosmavroeidis_the-role-of-openc2-in-cybersecurity-automation-activity-6925464109844938752-ph0I?">
+              Presentation on the Role of OpenC2 in Cybersecurity Automation</a>.
+              <br>
+              Dr. Vasileios Mavroeidis, a member of the OpenC2
+              TC, gave a talk on "the role of OpenC2 in
+              cybersecurity automation" at the <a rel="noopener
+              noreferrer" target="_blank"
+              href="https://www.finsec-project.eu/second-ecsci-virtual-workshop"></a>2nd
+              ECSCI Workshop on Critical Infrastructure
+              Protection</a>, organized by the European Cluster
+              for Securing Critical Infrastructures (ECSCI). 
+          </p>
+        </div>
+      </div>
+
+      <div class="timecard"  data-aos="fade-up">
+        <div class="content">
           <h6>April 12, 2022</h6>
           <p>
             <a rel="noopener noreferrer" target="_blank" href="https://www.mnemonic.io/resources/podcast/episode-64-the-science-of-soar/">

--- a/news.html
+++ b/news.html
@@ -11,6 +11,20 @@ permalink: /news.html
 
       <div class="timecard"  data-aos="fade-up">
         <div class="content">
+          <h6>April 12, 2022</h6>
+          <p>
+            <a rel="noopener noreferrer" target="_blank" href="https://www.mnemonic.io/resources/podcast/episode-64-the-science-of-soar/">
+              The Science of SOAR on security podcast</a>.
+              <br>
+              Dr. Vasileios Mavroeidis, a member of the OpenC2
+              TC, was a guest on the mnemonic security podcast,
+              to discuss "The Science of SOAR". 
+          </p>
+        </div>
+      </div>
+
+      <div class="timecard"  data-aos="fade-up">
+        <div class="content">
           <h6>January 19, 2022</h6>
           <p>
             <a rel="noopener noreferrer" target="_blank" href="https://www.oasis-open.org/2022/01/19/originbx-alliance-for-digital-trade-and-stix-taxii-cybersecurity-standards-win-open-cup-awards/">

--- a/news.html
+++ b/news.html
@@ -11,6 +11,22 @@ permalink: /news.html
 
       <div class="timecard"  data-aos="fade-up">
         <div class="content">
+          <h6>January 19, 2022</h6>
+          <p>
+            <a rel="noopener noreferrer" target="_blank" href="https://www.oasis-open.org/2022/01/19/originbx-alliance-for-digital-trade-and-stix-taxii-cybersecurity-standards-win-open-cup-awards/">
+              OpenC2 TC Co-Chair named OASIS Distinguished Contributor</a>.
+              <br>
+              Duncan Sparrell, a co-chair of the OpenC2 TC, was
+              named an <a rel="noopener noreferrer"
+              target="_blank"
+              href="https://www.oasis-open.org/members/distinguished-contributors/">OASIS
+              Distinguished Contributor</a>.
+          </p>
+        </div>
+      </div>
+
+      <div class="timecard"  data-aos="fade-up">
+        <div class="content">
           <h6>December 3, 2021</h6>
           <p>
             <a rel="noopener noreferrer" target="_blank" href="https://www.oasis-open.org/2021/12/03/specification-for-transfer-of-openc2-messages-via-https-v1-1-from-openc2-tc-approved-as-a-committee-specification/">

--- a/news.html
+++ b/news.html
@@ -11,6 +11,40 @@ permalink: /news.html
 
       <div class="timecard"  data-aos="fade-up">
         <div class="content">
+          <h6>June 3, 2022</h6>
+          <p>
+            <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202206/msg00000.html">
+              OASIS Publishes CSD01 of the OpenC2 Architecture Specification, v1.0</a>.
+              <br>
+            The Architecture Specification is the foundation
+            document defining the OpenC2 language. It describes
+            the fundamental structures of OpenC2 and provides a
+            blueprint for developing Actuator Profiles and
+            Transfer Specifications.
+          </p>
+        </div>
+      </div>
+
+      <div class="timecard"  data-aos="fade-up">
+        <div class="content">
+          <h6>June 2, 2022</h6>
+          <p>
+            <a rel="noopener noreferrer" target="_blank" href="https://www.cybersecurityautomationworkshop.org/">
+              OpenC2 Participates in Cybersecurity Automation Workshop (CAW)</a>.
+              <br>
+            Cybersecurity Automation Workshops are a series of
+            events to prototype and test interoperability among
+            cybersecurity automation technologies. OpenC2
+            participated in the latest CAW event, which also
+            explored related cybersecurity technologies including
+            as Software Bill of Materials (SBOM), security
+            Posture Attribute Collection & Evaluation (PACE).
+          </p>
+        </div>
+      </div>
+
+      <div class="timecard"  data-aos="fade-up">
+        <div class="content">
           <h6>April 28, 2022</h6>
           <p>
             <a rel="noopener noreferrer" target="_blank" href="https://www.linkedin.com/posts/vasileiosmavroeidis_the-role-of-openc2-in-cybersecurity-automation-activity-6925464109844938752-ph0I?">


### PR DESCRIPTION
Added news items:
   - 6/3/2022:  CSD01 of the Arch Spec published
   - 6/2/2022:  OpenC2 participated in the CAW
   - 4/28/2022:  Vasileios presented on OpenC2 at conference
   - 4/12/2022:  Vasileios was guest on mnemonic security podcast, discussing The Science of SOAR 
   - 1/19/2022:  Duncan named an OASIS Distinguished Contributor