### PR TITLE
Updates for OpenC2 Architecture Spec publication

### DIFF
--- a/content/homepage/carousel/slide3.html
+++ b/content/homepage/carousel/slide3.html
@@ -1,10 +1,10 @@
 <h2 class="animate__animated animate__fadeInDown">OpenC2: A Family of
 Specifications!</h2>
 
-<p class="animate__animated animate__fadeInUp">OpenC2 is defined across a family of specifications, including our Language Specification, Actuator Profiles, and Transfer Specifications. Our <a rel="noopener noreferrer" href="{{ site.baseurl }}/specifications.html">Specifications</a> page lists our published specifications. For more detail, see the <a rel="noopener noreferrer" href="{{ site.baseurl }}/pubhist.html">Publication History</a>. 
+<p class="animate__animated animate__fadeInUp">OpenC2 is defined across a family of specifications, including our Architecture Specification, Language Specification, Actuator Profiles, and Transfer Specifications. Our <a rel="noopener noreferrer" href="{{ site.baseurl }}/specifications.html">Specifications</a> page lists our published specifications. For more detail, see the <a rel="noopener noreferrer" href="{{ site.baseurl }}/pubhist.html">Publication History</a>. 
 </p>
 
-<p>We have <a rel="noopener noreferrer" target="_blank" href="https://github.com/oasis-tcs/openc2-tc-ops/blob/main/oc2-companion.md">a friendly guide</a> to how it all fits together, and also a <a rel="noopener noreferrer" target="_blank" href="https://www.sciencedirect.com/science/article/pii/S0167404820302728">more structured description</a> of the aspects of OpenC2.
+<p>We also have <a rel="noopener noreferrer" target="_blank" href="https://github.com/oasis-tcs/openc2-tc-ops/blob/main/oc2-companion.md">a friendly guide</a> to how it all fits together, and also a <a rel="noopener noreferrer" target="_blank" href="https://www.sciencedirect.com/science/article/pii/S0167404820302728">more structured description</a> of the aspects of OpenC2.
 </p>
 
 <a rel="noopener noreferrer" href="{{ site.baseurl}}/pubhist.html" class="btn-get-started animate__animated animate__fadeInUp scrollto">Read More</a>

--- a/content/homepage/carousel/slide4.html
+++ b/content/homepage/carousel/slide4.html
@@ -5,4 +5,4 @@
 
     Learn more about OpenC2 Specifications <a rel="noopener
     noreferrer" target="_blank"
-    href="https://openc2.org/specifications"> here.</a> 
+    href="https://openc2.org/specifications">here</a>.

--- a/content/homepage/carousel/slide4.html
+++ b/content/homepage/carousel/slide4.html
@@ -1,17 +1,8 @@
-<h2 class="animate__animated animate__fadeInDown">Cybersecurity
-Automation Workshop: 2 June 2022!</h2>
+<h2 class="animate__animated animate__fadeInDown">OpenC2 Architecture Committee Specification published! </h2>
 
-<p class="animate__animated animate__fadeInUp">OpenC2 TC members
-and others participated in a <a rel="noopener
-noreferrer" target="_blank"
-href="http://www.cybersecurityautomationworkshop.org/">
-Cybersecurity Automation Workshop</a> plugfest event on June 2nd.
-Workshop participants tested use cases related to SBOM
-retrieval, security <a rel="noopener noreferrer" target="_blank"
-href="https://github.com/opencybersecurityalliance/PACE">posture
-attribute collection</a>a, and other cyberssecurity automation
-technologies.</p>
+<p class="animate__animated animate__fadeInUp">The OpenC2 TC has <a rel="noopener noreferrer" target="_blank"
+    href="https://www.oasis-open.org/2022/10/24/open-command-and-control-openc2-architecture-v1-0-approved-as-a-committee-specification/">approved the <i>OpenC2 Architecture Specification v1.0</i> as an OASIS Committee Specification</a>a. This specification describes the abstract architecture of OpenC2 to define a common understanding of the messages and interactions for all bindings and serializations. It explains the various types of specifications in the OpenC2 family, gives an overview of their structure, and discusses how OpenC2 capabilities might be deployed in cyber defense systems. </p>
 
-<a rel="noopener noreferrer" target="_blank"
-href="http://www.cybersecurityautomationworkshop.org/">
-Learn more here.</a> 
+    Learn more about OpenC2 Specifications <a rel="noopener
+    noreferrer" target="_blank"
+    href="https://openc2.org/specifications"> here.</a> 

--- a/news.html
+++ b/news.html
@@ -14,7 +14,7 @@ permalink: /news.html
           <h6>September 30, 2022</h6>
           <p>
             <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202206/msg00000.html">
-              Open Command and Control (OpenC2) Architecture v1.0 approved as a Committee Specification</a>.
+              Open Command and Control (OpenC2) Architecture v1.0 approved as an OASIS Committee Specification</a>.
               <br>
               The Architecture Specification is an overarching
               document that describes the concepts and organization

--- a/news.html
+++ b/news.html
@@ -11,6 +11,24 @@ permalink: /news.html
 
       <div class="timecard"  data-aos="fade-up">
         <div class="content">
+          <h6>September 30, 2022</h6>
+          <p>
+            <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202206/msg00000.html">
+              Open Command and Control (OpenC2) Architecture v1.0 approved as a Committee Specification</a>.
+              <br>
+              The Architecture Specification is an overarching
+              document that describes the concepts and organization
+              of OpenC2, and provides a blueprint for developing
+              Actuator Profiles and Transfer Specifications. It
+              also describes the abstract architecture of OpenC2 to
+              define a common understanding of the messages and
+              interactions for all bindings and serializations.
+          </p>
+        </div>
+      </div>
+
+      <div class="timecard"  data-aos="fade-up">
+        <div class="content">
           <h6>June 3, 2022</h6>
           <p>
             <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202206/msg00000.html">

--- a/pubhist.html
+++ b/pubhist.html
@@ -302,13 +302,25 @@ permalink: /pubhist.html
         </td>
         <td data-label="Publication Date">11 May 2022</td>
       <tr>
-      <tr>
+        <tr>
+          <td data-label="Version">v1.0</td>
+          <td data-label="Approval Level">
+            <a
+              rel="noopener noreferrer"
+              target="_blank"
+              href="https://github.com/oasis-tcs/openc2-oc2arch/blob/working/oc2arch-v1.0.md"
+              CS01</a
+            >
+          </td>
+          <td data-label="Publication Date">30 September 2022</td>
+        <tr>
+        <tr>
         <td data-label="Version">v1.0</td>
         <td data-label="Approval Level">
           <a
             rel="noopener noreferrer"
             target="_blank"
-            href="https://docs.oasis-open.org/openc2/oc2arch/v1.0/csd01/oc2arch-v1.0-csd01.html"
+            href="https://docs.oasis-open.org/openc2/oc2arch/v1.0/cs01/oc2arch-v1.0-cs01.html"
             >CSD 01</a
           >
         </td>

--- a/pubhist.html
+++ b/pubhist.html
@@ -17,7 +17,7 @@ permalink: /pubhist.html
           with links to the most recent “approved” version as well as the
           current work-in-progress for the product. An entry is provided for
           each work product. For each document the reference includes the full
-          title, a brief descripotions, and a table
+          title, a brief descriptions, and a table
           with the following information for “approved” versions:
         </p>
         <ul>
@@ -49,7 +49,7 @@ permalink: /pubhist.html
               and usable but unfinished specification.
             </li>
             <li>
-              <em>Committee Specification</em> / Public Review Draft (CSPRD) --
+              <em>Committee Specification</em> / Public Review Draft (CS/PRD) --
               an official OASIS publication approved by a majority vote of the
               TC and specified for release for public review (this terminology
               only applies to the TC’s original three specifications).
@@ -79,7 +79,85 @@ permalink: /pubhist.html
       </div>
     </div>
 
+<!--- Section for the Architecture Specification -->
 
+<div class="container" id='PF AP'>
+  <div class="section-title">
+    <h2>OpenC2 Architecture Specification</h2>
+    <p class="section-subtitle">
+      <i>Cyber attacks are increasingly sophisticated, less
+      expensive to execute, dynamic and automated. The provision
+      of cyber defense via statically configured products
+      operating in isolation is untenable. Standardized
+      interfaces, protocols and data models will facilitate the
+      integration of the functional blocks within a system and
+      between systems. Open Command and Control (OpenC2) is a
+      concise and extensible language to enable
+      machine-to-machine communications for purposes of command
+      and control of cyber defense components, subsystems and/or
+      systems in a manner that is agnostic of the underlying
+      products, technologies, transport mechanisms or other
+      aspects of the implementation. The Architecture
+      Specification describes the abstract architecture of OpenC2
+      to define a common understanding of the messages and
+      interactions for all bindings and serializations.
+      </i>
+    </p>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">Version</th>
+        <th scope="col">Approval Level</th>
+        <th scope="col">Publication Date</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td data-label="Version">v1.0 WIP</td>
+        <td data-label="Approval Level">
+          <a
+            rel="noopener noreferrer"
+            target="_blank"
+            href="https://github.com/oasis-tcs/openc2-oc2arch/blob/working/oc2arch-v1.0.md"
+            >Working Meeting: 11 May 2022</a
+          >
+        </td>
+        <td data-label="Publication Date">11 May 2022</td>
+      <tr>
+        <tr>
+          <td data-label="Version">v1.0</td>
+          <td data-label="Approval Level">
+            <a
+              rel="noopener noreferrer"
+              target="_blank"
+              href="https://github.com/oasis-tcs/openc2-oc2arch/blob/working/oc2arch-v1.0.md">
+              CS01
+            </a>
+          </td>
+          <td data-label="Publication Date">30 September 2022</td>
+        <tr>
+        <tr>
+        <td data-label="Version">v1.0</td>
+        <td data-label="Approval Level">
+          <a
+            rel="noopener noreferrer"
+            target="_blank"
+            href="https://docs.oasis-open.org/openc2/oc2arch/v1.0/cs01/oc2arch-v1.0-cs01.html"
+            >CSD 01</a
+          >
+        </td>
+        <td data-label="Publication Date">18 May 2022</td>
+      </tr>
+    </tbody>
+  </table>
+  <br /><br />
+</div>
+
+
+
+<!--- Section for the Language Specification -->
 
     <div class="container" id="language spec">
       <div class="section-title">
@@ -255,83 +333,10 @@ permalink: /pubhist.html
       <br /><br />
     </div>
 
-<!--- Section for the Architecture Specification -->
-
-<div class="container" id='PF AP'>
-  <div class="section-title">
-    <h2>OpenC2 Architecture Specification</h2>
-    <p class="section-subtitle">
-      <i>Cyberattacks are increasingly sophisticated, less
-      expensive to execute, dynamic and automated. The provision
-      of cyber defense via statically configured products
-      operating in isolation is untenable. Standardized
-      interfaces, protocols and data models will facilitate the
-      integration of the functional blocks within a system and
-      between systems. Open Command and Control (OpenC2) is a
-      concise and extensible language to enable
-      machine-to-machine communications for purposes of command
-      and control of cyber defense components, subsystems and/or
-      systems in a manner that is agnostic of the underlying
-      products, technologies, transport mechanisms or other
-      aspects of the implementation. The Architecture
-      Specification describes the abstract architecture of OpenC2
-      to define a common understanding of the messages and
-      interactions for all bindings and serializations.
-      </i>
-    </p>
-  </div>
-
-  <table>
-    <thead>
-      <tr>
-        <th scope="col">Version</th>
-        <th scope="col">Approval Level</th>
-        <th scope="col">Publication Date</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td data-label="Version">v1.0 WIP</td>
-        <td data-label="Approval Level">
-          <a
-            rel="noopener noreferrer"
-            target="_blank"
-            href="https://github.com/oasis-tcs/openc2-oc2arch/blob/working/oc2arch-v1.0.md"
-            >Working Meeting: 11 May 2022</a
-          >
-        </td>
-        <td data-label="Publication Date">11 May 2022</td>
-      <tr>
-        <tr>
-          <td data-label="Version">v1.0</td>
-          <td data-label="Approval Level">
-            <a
-              rel="noopener noreferrer"
-              target="_blank"
-              href="https://github.com/oasis-tcs/openc2-oc2arch/blob/working/oc2arch-v1.0.md"
-              CS01</a
-            >
-          </td>
-          <td data-label="Publication Date">30 September 2022</td>
-        <tr>
-        <tr>
-        <td data-label="Version">v1.0</td>
-        <td data-label="Approval Level">
-          <a
-            rel="noopener noreferrer"
-            target="_blank"
-            href="https://docs.oasis-open.org/openc2/oc2arch/v1.0/cs01/oc2arch-v1.0-cs01.html"
-            >CSD 01</a
-          >
-        </td>
-        <td data-label="Publication Date">18 May 2022</td>
-      </tr>
-    </tbody>
-  </table>
-  <br /><br />
-</div>
 
 
+
+<!--- Section for the Stateless Packet Filtering (SLPF) AP -->
 
 
 

--- a/specifications.html
+++ b/specifications.html
@@ -15,6 +15,11 @@ permalink: /specifications.html
       <ul>
         <li>
           <a rel="noopener noreferrer" target="_blank"
+            href="https://docs.oasis-open.org/openc2/oc2arch/v1.0/cs01/oc2arch-v1.0-cs01.html">Open Command and Control
+            (OpenC2) Architecture Specification Version 1.0</a>
+        </li>
+        <li>
+          <a rel="noopener noreferrer" target="_blank"
             href="https://docs.oasis-open.org/openc2/oc2ls/v1.0/cs02/oc2ls-v1.0-cs02.html">Open Command and Control
             (OpenC2) Language Specification Version 1.0</a>
         </li>


### PR DESCRIPTION
This PR:

- Updates carousel slide 3 to include the architecture as a type of specification
- Replaces CAW material on slide 4 with an Architecture Specification publication announcement
- Add the Architecture to the list of published spec on the Specifications page
- Adds a link to the OASIS announcement to the In The News page
- Adds the Architecture CS to the appropriate table in publication history, and moves that document to the top of that page