### PR TITLE
Update News and Pub History for LS v2.0, CSD01

### DIFF
--- a/news.html
+++ b/news.html
@@ -11,6 +11,24 @@ permalink: /news.html
 
       <div class="timecard"  data-aos="fade-up">
         <div class="content">
+          <h6>November 16, 2022</h6>
+          <p>
+            <a rel="noopener noreferrer" target="_blank" href="https://docs.oasis-open.org/openc2/oc2ls/v2.0/csd01/oc2ls-v2.0-csd01.html">
+              OASIS Publishes CSD01 of the OpenC2 Language Specification, v2.0</a>.
+              <br>
+            The Language Specification is the foundation document
+            defining the OpenC2 language. The TC has determined
+            to advance the Language Specification to Version 2.0
+            to address changes identified since the November 2019
+            publication of v1.0, CSD02, including a small number
+            of breaking changes. CSD01 is the initial publication
+            of the in-development v.20 specification.
+          </p>
+        </div>
+      </div>
+
+      <div class="timecard"  data-aos="fade-up">
+        <div class="content">
           <h6>September 30, 2022</h6>
           <p>
             <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/openc2/202206/msg00000.html">

--- a/pubhist.html
+++ b/pubhist.html
@@ -185,16 +185,28 @@ permalink: /pubhist.html
         </thead>
         <tbody>
           <tr>
-            <td data-label="Version">v1.1 WIP</td>
+            <td data-label="Version">v2.0 WIP</td>
             <td data-label="Approval Level">
               <a
                 rel="noopener noreferrer"
                 target="_blank"
                 href="https://github.com/oasis-tcs/openc2-oc2ls/blob/working/oc2ls.md"
-                >Working Meeting: 22 September 2021</a
+                >Working Meeting: 4 January 2023</a
               >
             </td>
             <td data-label="Publication Date">22 September 2021</td>
+          </tr>
+          <tr>
+            <td data-label="Version">v2.0</td>
+            <td data-label="Approval Level">
+              <a
+                rel="noopener noreferrer"
+                target="_blank"
+                href="https://docs.oasis-open.org/openc2/oc2ls/v2.0/csd01/oc2ls-v2.0-csd01.html"
+                >CSD 01</a
+              >
+            </td>
+            <td data-label="Publication Date">16 November 2022</td>
           </tr>
           <tr>
             <td data-label="Version">v1.1</td>


### PR DESCRIPTION
This PR records the November 2022 publication of the CSD01 of LS v2.0:

 - adds an item to the In The News page
 - adds a line to the Language Specification publication  history table, and updates the WIP line to reference v2.0