### PR TITLE
Update website for JADN-IM CN publication

### DIFF
--- a/_news/news_20230419.md
+++ b/_news/news_20230419.md
@@ -1,0 +1,17 @@
+---
+screen-date:  April 19, 2023
+sort-date: 20230419
+title: Information Modeling with JADN Version 1.0 Published as OASIS Committee Note 
+title-url: https://docs.oasis-open.org/openc2/imjadn/v1.0/imjadn-v1.0.html
+---
+
+OASIS has published Committee Note 01 of _Information Modeling
+with JADN v1.0_. This CN, a companion to the <a rel="noopener
+noreferrer" target="_blank"
+href="https://docs.oasis-open.org/openc2/jadn/v1.0/cs01/jadn-v1.0-cs01.html">*JADN
+Specification*</a>, was approved for publication by the OpenC2
+TC. The CN describes the use of IMs, contains explanations of the
+JADN language, explains how to construct IMs using JADN with
+examples, and contrasts IMs with other modeling approaches, such
+as Entity-Relationship models for databases, and knowledge models
+/ ontologies.

--- a/content/homepage/carousel/slide4.html
+++ b/content/homepage/carousel/slide4.html
@@ -1,7 +1,13 @@
-<h2 class="animate__animated animate__fadeInDown">OpenC2 Architecture Committee Specification published! </h2>
+<h2 class="animate__animated animate__fadeInDown"><i>Information Modeling with JADN</i> Committee Note published! </h2>
 
-<p class="animate__animated animate__fadeInUp">The OpenC2 TC has <a rel="noopener noreferrer" target="_blank"
-    href="https://www.oasis-open.org/2022/10/24/open-command-and-control-openc2-architecture-v1-0-approved-as-a-committee-specification/">approved the <i>OpenC2 Architecture Specification v1.0</i> as an OASIS Committee Specification</a>. This specification describes the abstract architecture of OpenC2 to define a common understanding of the messages and interactions for all bindings and serializations. It explains the various types of specifications in the OpenC2 family, gives an overview of their structure, and discusses how OpenC2 capabilities might be deployed in cyber defense systems. </p>
+<p class="animate__animated animate__fadeInUp">The OpenC2 TC has approved 
+<a rel="noopener noreferrer" target="_blank"
+href="https://docs.oasis-open.org/openc2/imjadn/v1.0/imjadn-v1.0.html">
+<i>Information Modeling with JADN v1.0</i></a> as an OASIS
+Committee Note. This CN describes the use of Information Models,
+explains how to construct IMs using JADN, and contrasts IMs with
+other modeling approaches, such as Entity-Relationship models for
+databases, and knowledge models / ontologies. </p>
 
     Learn more about OpenC2 Specifications <a rel="noopener
     noreferrer" target="_blank"

--- a/pubhist.html
+++ b/pubhist.html
@@ -907,74 +907,76 @@ permalink: /pubhist.html
           </tr>
         </tbody>
       </table>
+      <br /><br />
     </div>
 
-      <div class="container" id="jadn-im">
-        <div class="section-title">
-          <h2>Specification for JSON Abstract Data Notation (JADN)</h2>
-          <p class="section-subtitle">
-            <i>Information models (IMs) are used to define and
-            generate physical data models, validate information
-            instances, and enable lossless translation across
-            data formats. JSON Abstract Data Notation (JADN) is a
-            UML-based information modeling language that defines
-            data structure independently of data format. This
-            Committee Note describes the use of IMs, explains how
-            to construct IMs using JADN, and contrasts IMs with
-            other modeling approaches, such as
-            Entity-Relationship models for databases, and
-            knowledge models / ontologies.
-            </i>
-          </p>
-        </div>
-  
-        <table>
-          <thead>
-            <tr>
-              <th scope="col">Version</th>
-              <th scope="col">Approval Level</th>
-              <th scope="col">Publication Date</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td data-label="Version">v1.X WIP</td>
-              <td data-label="Approval Level">
-                <a
-                  rel="noopener noreferrer"
-                  target="_blank"
-                  href="https://github.com/oasis-tcs/openc2-jadn-im/blob/working/imjadn-v1.0-cn01.md"
-                  >Working Meeting: 12 April 2023</a
-                >
-              </td>
-              <td data-label="Publication Date">12 April 2023</td>
-            <tr>
-            <tr>
-              <td data-label="Version">v1.0</td>
-              <td data-label="Approval Level">
-                <a
-                  rel="noopener noreferrer"
-                  target="_blank"
-                  href="https://docs.oasis-open.org/openc2/imjadn/v1.0/imjadn-v1.0.html"
-                  >CN 01</a
-                >
-              </td>
-              <td data-label="Publication Date">19 April 2023</td>
-            </tr>
-            <tr>
-              <td data-label="Version">v1.0</td>
-              <td data-label="Approval Level">
-                <a
-                  rel="noopener noreferrer"
-                  target="_blank"
-                  href="https://docs.oasis-open.org/openc2/imjadn/v1.0/cnd01/imjadn-v1.0-cnd01.html"
-                  >CND 01</a> 
-              </td>
-              <td data-label="Publication Date">18 January 2023</td>
-            </tr>
-          </tbody>
-        </table>
-        <br /><br />
+
+    <div class="container" id="jadn-im">
+      <div class="section-title">
+        <h2>Information Modeling With JADN</h2>
+        <p class="section-subtitle">
+          <i>Information models (IMs) are used to define and
+          generate physical data models, validate information
+          instances, and enable lossless translation across
+          data formats. JSON Abstract Data Notation (JADN) is a
+          UML-based information modeling language that defines
+          data structure independently of data format. This
+          Committee Note describes the use of IMs, explains how
+          to construct IMs using JADN, and contrasts IMs with
+          other modeling approaches, such as
+          Entity-Relationship models for databases, and
+          knowledge models / ontologies.
+          </i>
+        </p>
+      </div>
+
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Version</th>
+            <th scope="col">Approval Level</th>
+            <th scope="col">Publication Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td data-label="Version">v1.X WIP</td>
+            <td data-label="Approval Level">
+              <a
+                rel="noopener noreferrer"
+                target="_blank"
+                href="https://github.com/oasis-tcs/openc2-jadn-im/blob/working/imjadn-v1.0-cn01.md"
+                >Working Meeting: 12 April 2023</a
+              >
+            </td>
+            <td data-label="Publication Date">12 April 2023</td>
+          <tr>
+          <tr>
+            <td data-label="Version">v1.0</td>
+            <td data-label="Approval Level">
+              <a
+                rel="noopener noreferrer"
+                target="_blank"
+                href="https://docs.oasis-open.org/openc2/imjadn/v1.0/imjadn-v1.0.html"
+                >CN 01</a
+              >
+            </td>
+            <td data-label="Publication Date">19 April 2023</td>
+          </tr>
+          <tr>
+            <td data-label="Version">v1.0</td>
+            <td data-label="Approval Level">
+              <a
+                rel="noopener noreferrer"
+                target="_blank"
+                href="https://docs.oasis-open.org/openc2/imjadn/v1.0/cnd01/imjadn-v1.0-cnd01.html"
+                >CND 01</a> 
+            </td>
+            <td data-label="Publication Date">18 January 2023</td>
+          </tr>
+        </tbody>
+      </table>
+      <br /><br />
     </div>
   </section>
 </main>

--- a/pubhist.html
+++ b/pubhist.html
@@ -81,7 +81,7 @@ permalink: /pubhist.html
 
 <!--- Section for the Architecture Specification -->
 
-<div class="container" id='PF AP'>
+<div class="container" id="arch-spec">
   <div class="section-title">
     <h2>OpenC2 Architecture Specification</h2>
     <p class="section-subtitle">
@@ -159,7 +159,7 @@ permalink: /pubhist.html
 
 <!--- Section for the Language Specification -->
 
-    <div class="container" id="language spec">
+    <div class="container" id="lang-spec">
       <div class="section-title">
         <h2>Open Command and Control (OpenC2) Language Specification</h2>
         <p class="section-subtitle">
@@ -535,7 +535,7 @@ permalink: /pubhist.html
 
 <!--- Section for the Posture Attribute Collection AP -->
 
-<div class="container" id='PF AP'>
+<div class="container" id='PAC AP'>
   <div class="section-title">
     <h2>OpenC2 Actuator Profile for Posture Attribute Collection (PAC)</h2>
     <p class="section-subtitle">
@@ -907,7 +907,74 @@ permalink: /pubhist.html
           </tr>
         </tbody>
       </table>
-      <br /><br />
+    </div>
+
+      <div class="container" id="jadn-im">
+        <div class="section-title">
+          <h2>Specification for JSON Abstract Data Notation (JADN)</h2>
+          <p class="section-subtitle">
+            <i>Information models (IMs) are used to define and
+            generate physical data models, validate information
+            instances, and enable lossless translation across
+            data formats. JSON Abstract Data Notation (JADN) is a
+            UML-based information modeling language that defines
+            data structure independently of data format. This
+            Committee Note describes the use of IMs, explains how
+            to construct IMs using JADN, and contrasts IMs with
+            other modeling approaches, such as
+            Entity-Relationship models for databases, and
+            knowledge models / ontologies.
+            </i>
+          </p>
+        </div>
+  
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Version</th>
+              <th scope="col">Approval Level</th>
+              <th scope="col">Publication Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td data-label="Version">v1.X WIP</td>
+              <td data-label="Approval Level">
+                <a
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  href="https://github.com/oasis-tcs/openc2-jadn-im/blob/working/imjadn-v1.0-cn01.md"
+                  >Working Meeting: 12 April 2023</a
+                >
+              </td>
+              <td data-label="Publication Date">12 April 2023</td>
+            <tr>
+            <tr>
+              <td data-label="Version">v1.0</td>
+              <td data-label="Approval Level">
+                <a
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  href="https://docs.oasis-open.org/openc2/imjadn/v1.0/imjadn-v1.0.html"
+                  >CN 01</a
+                >
+              </td>
+              <td data-label="Publication Date">19 April 2023</td>
+            </tr>
+            <tr>
+              <td data-label="Version">v1.0</td>
+              <td data-label="Approval Level">
+                <a
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  href="https://docs.oasis-open.org/openc2/imjadn/v1.0/cnd01/imjadn-v1.0-cnd01.html"
+                  >CND 01</a> 
+              </td>
+              <td data-label="Publication Date">18 January 2023</td>
+            </tr>
+          </tbody>
+        </table>
+        <br /><br />
     </div>
   </section>
 </main>

--- a/specifications.html
+++ b/specifications.html
@@ -25,10 +25,6 @@ permalink: /specifications.html
         </li>
         <li>
           <a rel="noopener noreferrer" target="_blank"
-            href="https://docs.oasis-open.org/openc2/jadn/v1.0/cs01/jadn-v1.0-cs01.html">OpenC2's JSON Abstract Data Notation (JADN) Version 1.0</a>
-        </li>
-        <li>
-          <a rel="noopener noreferrer" target="_blank"
             href="https://docs.oasis-open.org/openc2/oc2slpf/v1.0/cs01/oc2slpf-v1.0-cs01.html">Open Command and
             Control (OpenC2) Profile for Stateless Packet Filtering (SLPF) Version 1.0
           </a>
@@ -43,6 +39,14 @@ permalink: /specifications.html
             href="https://docs.oasis-open.org/openc2/transf-mqtt/v1.0/cs01/transf-mqtt-v1.0-cs01.html">Specification
             for Transfer of OpenC2 Messages via MQTT Version 1.0
           </a>
+        </li>
+        <li>
+          <a rel="noopener noreferrer" target="_blank"
+            href="https://docs.oasis-open.org/openc2/jadn/v1.0/cs01/jadn-v1.0-cs01.html">JSON Abstract Data Notation (JADN) Version 1.0</a>
+        </li>
+        <li>
+          <a rel="noopener noreferrer" target="_blank"
+            href="https://docs.oasis-open.org/openc2/jadn/v1.0/cs01/jadn-v1.0-cs01.html">Information Modeling with JADN Version 1.0 (CN01)</a>
         </li>
       </ul>
 


### PR DESCRIPTION
Changes:

- Update Carousel slide 4 to JADN-IM CN
- Update Specifications page
- Add JADN-IM CN to Publication History page
- Add a news item for the publication of the CN