### PR TITLE
home page text updates

### DIFF
--- a/_news/news_20231206.md
+++ b/_news/news_20231206.md
@@ -11,10 +11,10 @@ event. A [test matrix](https://github.com/opencybersecurityalliance/casp/blob/ma
 is being developed to document participants' planned contributions and
 facilitate identifying opportunities to demonstrate interoperability. A second
 preparation session is planned for early March 2024, and the
-CAV will be held April 11-12 at Peraton's offices at 1875 Explorer St, Reston, VA 20190.
+Village will be held April 11-12 at Peraton's offices at 1875 Explorer St, Reston, VA 20190.
 
 The [CASP GitHub repository](https://github.com/opencybersecurityalliance/casp)
 contains detailed information and is the place to sign up to participate and
-contribute to the CAV. The [CASP mailing
+contribute to the Village. The [CASP mailing
 list](https://lists.oasis-open-projects.org/g/oca-casp/topics) is also a
 coordination resource.

--- a/_news/news_20231206.md
+++ b/_news/news_20231206.md
@@ -1,17 +1,17 @@
 ---
 screen-date:  December 6, 2023
 sort-date: 20231206
-title: Preparations for March Cybersecurity Automation Village (Take 1)
+title: Preparations for April Cybersecurity Automation Village
 title-url: https://github.com/opencybersecurityalliance/casp
 ---
 
-OpenC2 TC members will be participating in the first preparation session for a planned 
-[March 2024 Cybersecurity Automation Village (CAV)](https://github.com/opencybersecurityalliance/casp/tree/main/Plugfests/2024-03-NorthernVirginia)
+OpenC2 TC members will be participated in the first preparation session (December 6th) for a planned 
+[April 2024 Cybersecurity Automation Village (CAV)](https://github.com/opencybersecurityalliance/casp/tree/main/Plugfests/2024-03-NorthernVirginia)
 event. A [test matrix](https://github.com/opencybersecurityalliance/casp/blob/main/Plugfests/2024-03-NorthernVirginia/test-matrix-2024-03.md)
 is being developed to document participants' planned contributions and
 facilitate identifying opportunities to demonstrate interoperability. A second
-preparation session is planned for late January or early Febraury 2024, and the
-CAV will be held March 14-15 at Peraton's offices at 1875 Explorer St, Reston, VA 20190.
+preparation session is planned for early March 2024, and the
+CAV will be held April 11-12 at Peraton's offices at 1875 Explorer St, Reston, VA 20190.
 
 The [CASP GitHub repository](https://github.com/opencybersecurityalliance/casp)
 contains detailed information and is the place to sign up to participate and

--- a/_news/news_20231206.md
+++ b/_news/news_20231206.md
@@ -5,7 +5,7 @@ title: Preparations for April Cybersecurity Automation Village
 title-url: https://github.com/opencybersecurityalliance/casp
 ---
 
-OpenC2 TC members will be participated in the first preparation session (December 6th) for a planned 
+OpenC2 TC members participated in the first preparation session (December 6th) for a planned 
 [April 2024 Cybersecurity Automation Village (CAV)](https://github.com/opencybersecurityalliance/casp/tree/main/Plugfests/2024-03-NorthernVirginia)
 event. A [test matrix](https://github.com/opencybersecurityalliance/casp/blob/main/Plugfests/2024-03-NorthernVirginia/test-matrix-2024-03.md)
 is being developed to document participants' planned contributions and

--- a/content/homepage/carousel/slide4.html
+++ b/content/homepage/carousel/slide4.html
@@ -7,8 +7,7 @@ href="https://docs.oasis-open.org/openc2/imjadn/v1.0/imjadn-v1.0.html">
 Committee Note. This CN describes the use of Information Models,
 explains how to construct IMs using JADN, and contrasts IMs with
 other modeling approaches, such as Entity-Relationship models for
-databases, and knowledge models / ontologies. </p>
-
-    Learn more about OpenC2 Specifications <a rel="noopener
-    noreferrer" target="_blank"
-    href="https://openc2.org/specifications">here</a>.
+databases, and knowledge models / ontologies.
+<br><br>
+Learn more about OpenC2 Specifications <a rel="noopener noreferrer"
+target="_blank" href="https://openc2.org/specifications">here</a>.</p>

--- a/content/homepage/carousel/slide5.html
+++ b/content/homepage/carousel/slide5.html
@@ -1,16 +1,16 @@
-<h2 class="animate__animated animate__fadeInDown">June 2023 Cybersecurity Automation Village</h2>
+<h2 class="animate__animated animate__fadeInDown">April 2024 Cybersecurity Automation Village</h2>
 
 <p class="animate__animated animate__fadeInUp">OpenC2 TC member
 organizations will be participating in the 
-<a rel="noopener noreferrer" target="_blank" href="https://github.com/opencybersecurityalliance/casp/blob/main/Plugfests/NextPlugfest/2023-06-13-USC">
-13 June 2023 Cybersecurity Automation Village</a>. The Village,
+<a rel="noopener noreferrer" target="_blank" href="https://github.com/opencybersecurityalliance/casp/tree/main/Plugfests/2024-03-NorthernVirginia">
+11-12 April 2024 Cybersecurity Automation Village</a>. The Village,
 sponsored by the <a rel="noopener noreferrer" target="_blank"
 href="https://opencybersecurityalliance.org/">Open Cybersecurity
 Alliance</a> CASP subproject, is for sharing information,
 prototyping, testing, and specifying interoperability among
 cybersecurity automation technologies.</p> 
 
-OpenC2 will participate in use cases involving the 
+<p class="animate__animated animate__fadeInUp"></p>OpenC2 will participate in use cases involving the 
 <a rel="noopener noreferrer" target="_blank" href="https://github.com/opencybersecurityalliance/kestrel-lang">Kestrel</a> Threat Hunting Language and 
 <a rel="noopener noreferrer" target="_blank" href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=cacao">CACAO-based</a> automation.
-
+</p>

--- a/content/homepage/carousel/slide5.html
+++ b/content/homepage/carousel/slide5.html
@@ -8,9 +8,9 @@ sponsored by the <a rel="noopener noreferrer" target="_blank"
 href="https://opencybersecurityalliance.org/">Open Cybersecurity
 Alliance</a> CASP subproject, is for sharing information,
 prototyping, testing, and specifying interoperability among
-cybersecurity automation technologies.</p> 
-
-<p class="animate__animated animate__fadeInUp">OpenC2 will participate in use cases involving the 
+cybersecurity automation technologies. 
+<br><br>
+OpenC2 will participate in use cases involving the 
 <a rel="noopener noreferrer" target="_blank" href="https://github.com/opencybersecurityalliance/kestrel-lang">Kestrel</a> Threat Hunting Language and 
 <a rel="noopener noreferrer" target="_blank" href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=cacao">CACAO-based</a> automation.
 </p>

--- a/content/homepage/carousel/slide5.html
+++ b/content/homepage/carousel/slide5.html
@@ -9,7 +9,6 @@ href="https://opencybersecurityalliance.org/">Open Cybersecurity
 Alliance</a> CASP subproject, is for sharing information,
 prototyping, testing, and specifying interoperability among
 cybersecurity automation technologies. 
-<br><br>
 OpenC2 will participate in use cases involving the 
 <a rel="noopener noreferrer" target="_blank" href="https://github.com/opencybersecurityalliance/kestrel-lang">Kestrel</a> Threat Hunting Language and 
 <a rel="noopener noreferrer" target="_blank" href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=cacao">CACAO-based</a> automation.

--- a/content/homepage/carousel/slide5.html
+++ b/content/homepage/carousel/slide5.html
@@ -9,7 +9,7 @@ href="https://opencybersecurityalliance.org/">Open Cybersecurity
 Alliance</a> CASP subproject, is for sharing information,
 prototyping, testing, and specifying interoperability among
 cybersecurity automation technologies. 
-OpenC2 will participate in use cases involving the 
+<br><br>OpenC2 will participate in use cases involving the 
 <a rel="noopener noreferrer" target="_blank" href="https://github.com/opencybersecurityalliance/kestrel-lang">Kestrel</a> Threat Hunting Language and 
 <a rel="noopener noreferrer" target="_blank" href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=cacao">CACAO-based</a> automation.
 </p>

--- a/content/homepage/carousel/slide5.html
+++ b/content/homepage/carousel/slide5.html
@@ -10,7 +10,7 @@ Alliance</a> CASP subproject, is for sharing information,
 prototyping, testing, and specifying interoperability among
 cybersecurity automation technologies.</p> 
 
-<p class="animate__animated animate__fadeInUp"></p>OpenC2 will participate in use cases involving the 
+<p class="animate__animated animate__fadeInUp">OpenC2 will participate in use cases involving the 
 <a rel="noopener noreferrer" target="_blank" href="https://github.com/opencybersecurityalliance/kestrel-lang">Kestrel</a> Threat Hunting Language and 
 <a rel="noopener noreferrer" target="_blank" href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=cacao">CACAO-based</a> automation.
 </p>

--- a/content/homepage/current-cyberdefense.md
+++ b/content/homepage/current-cyberdefense.md
@@ -1,3 +1,10 @@
-Today, cyber defense technologies, systems and applications often use proprietary software and commands to control system configurations. Most environments within a company or enterprise are comprised of hundreds of different types of cyber-defense devices.
+Today, cyber defense technologies, systems and applications often use
+proprietary software and commands to control system configurations. Most
+environments within a company or enterprise are comprised of hundreds of
+different types of cyber-defense devices. _This highlights the
+importance of interconnecting an organization's cybersecurity solutions to
+ensure ongoing and effective threat management._
 
-When security incidents are detected or configuration changes are required, manual commands and real time system updates are required, increasing incident response time and potentially introducing human error.
+When security incidents are detected or configuration changes are required,
+manual commands and real time system updates are required, increasing incident
+response time and potentially introducing human error.

--- a/content/homepage/current-cyberdefense.md
+++ b/content/homepage/current-cyberdefense.md
@@ -1,9 +1,9 @@
 Today, cyber defense technologies, systems and applications often use
 proprietary software and commands to control system configurations. Most
 environments within a company or enterprise are comprised of hundreds of
-different types of cyber-defense devices. _This highlights the
+different types of cyber-defense devices. This highlights the
 importance of interconnecting an organization's cybersecurity solutions to
-ensure ongoing and effective threat management._
+ensure ongoing and effective threat management.
 
 When security incidents are detected or configuration changes are required,
 manual commands and real time system updates are required, increasing incident

--- a/content/homepage/defense-cybertime.md
+++ b/content/homepage/defense-cybertime.md
@@ -1,8 +1,8 @@
-_Integrations reduce the level of manual efforts but  are costly to develop and
+Integrations reduce the level of manual efforts but  are costly to develop and
 maintain and rely heavily on proprietary communication interfaces. This requires
 reconfiguring parts or the entire defense ecosystem of the organization when
 tools are introduced or replaced or when there are updates to the APIs
-utilized._ Through OpenC2 and the use of standardized interfaces and protocols,
+utilized. Through OpenC2 and the use of standardized interfaces and protocols,
 interoperability across tools, vendors, technologies and programming languages
 is achieved.
 

--- a/content/homepage/defense-cybertime.md
+++ b/content/homepage/defense-cybertime.md
@@ -1,3 +1,11 @@
-Through OpenC2 and the use of standardized interfaces and protocols, interoperability across tools, vendors, technologies and programming languages is achieved.
+_Integrations reduce the level of manual efforts but  are costly to develop and
+maintain and rely heavily on proprietary communication interfaces. This requires
+reconfiguring parts or the entire defense ecosystem of the organization when
+tools are introduced or replaced or when there are updates to the APIs
+utilized._ Through OpenC2 and the use of standardized interfaces and protocols,
+interoperability across tools, vendors, technologies and programming languages
+is achieved.
 
-Security professionals can orchestrate automated, tactical threat responses across a wide range of cyber-defense technologies at speeds significantly greater than previously imagined.
+Security professionals can orchestrate automated, tactical threat responses
+across a wide range of cyber-defense technologies at speeds significantly
+greater than previously imagined.


### PR DESCRIPTION
Minor updates to the OpenC2 home page to pull in some wording from a Vasileios Mavroeidis talk, per a suggestion from @sparrell .  (_Italics highlight new text_ and will be removed prior to merging this PR).

Also, updates carousel slide from June 2023 CAV to April 2024 CAV (slide 5), adjusts formatting of slides 4 and 5, and edits December 6th In The News item to reflect updated CAV schedule.