### PR TITLE
Update OASIS links

### DIFF
--- a/_faqs/faq_100-W-I-OpenC2.md
+++ b/_faqs/faq_100-W-I-OpenC2.md
@@ -5,7 +5,7 @@ question: What is OpenC2?
 OpenC2 is a standardized language for machine-to-machine
 communications for the command and control of technologies that
 provide or support cyber defenses. The [OpenC2 Technical
-Committee](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2)
+Committee](https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296)
 is developing a suite of specifications that define the OpenC2
 architecture, language, tailor its use to specific cyber-defense
 functions, and specify how to convey OpenC2 messages using

--- a/_faqs/faq_110-D-B-OC2-OASIS.md
+++ b/_faqs/faq_110-D-B-OC2-OASIS.md
@@ -2,7 +2,7 @@
 question: What is the difference between OpenC2 and OASIS?
 ---
 
-[OpenC2](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2)
+[OpenC2](https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296)
 is an open source language, available for use and input across
 the cyber-security community. Many open source languages and
 technologies benefit from support of standards bodies, to help

--- a/_faqs/faq_120-OC2-Spec-Suite.md
+++ b/_faqs/faq_120-OC2-Spec-Suite.md
@@ -18,14 +18,14 @@ used in concert:
   the OpenC2 language.
 
 * [**OpenC2 Actuator
-  Profiles**](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2#technical)
+  Profiles**](https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296#technical)
   specify the subset of the OpenC2 language relevant in the
   context of specific actuator functions (e.g., [packet
   filtering](https://docs.oasis-open.org/openc2/oc2slpf/v1.0/oc2slpf-v1.0.html),
   honeypots).
 
 * [**OpenC2 Transfer
-  Specifications**](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2#technical)
+  Specifications**](https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296#technical)
   utilize existing protocols and standards (e.g.,
   [HTTPS](https://docs.oasis-open.org/openc2/open-impl-https/v1.1/cs01/open-impl-https-v1.1-cs01.html),
   [MQTT](https://docs.oasis-open.org/openc2/transf-mqtt/v1.0/transf-mqtt-v1.0.html))

--- a/_faqs/faq_140-Acces-OC2.md
+++ b/_faqs/faq_140-Acces-OC2.md
@@ -4,9 +4,9 @@ question: How can I access OpenC2 and JADN?
 
 OASIS Specifications are open for all to use. The TC's [home page
 at
-OASIS](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2)
+OASIS](https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296)
 lists the [officially published
-specifications](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2#technical).
+specifications](https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296#technical).
 This website includes a list of all [OpenC2 specifications
 (published and under
 development)](https://openc2.org/openc2-org.github.io/specifications.html),

--- a/_faqs/faq_200-RT-CACAO.md
+++ b/_faqs/faq_200-RT-CACAO.md
@@ -4,7 +4,7 @@ question: How does OpenC2 relate to the OASIS CACAO TC?
 
 The [CACAO (Collaborative Automated Course of Action Operations
 for Cyber Security)
-TC's](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=cacao)
+TC's](https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=b75cccb8-adc6-4de5-8b99-018dc7d322b6)
 goal is defining the standard for creating machine-readable
 course of action playbooks for cybersecurity operations. CACAO
 will have the ability of integrating different languages for

--- a/_news/news_20230524.md
+++ b/_news/news_20230524.md
@@ -16,5 +16,5 @@ interoperability among cybersecurity automation technologies.
 OpenC2 members will participate in use cases involving the
 [Kestrel](https://github.com/opencybersecurityalliance/kestrel-lang)
 Threat Hunting Language and
-[CACAO-based](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=cacao)
+[CACAO-based](https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=b75cccb8-adc6-4de5-8b99-018dc7d322b6)
 automation.

--- a/content/homepage/carousel/slide5.html
+++ b/content/homepage/carousel/slide5.html
@@ -11,5 +11,5 @@ prototyping, testing, and specifying interoperability among
 cybersecurity automation technologies. 
 <br><br>OpenC2 will participate in use cases involving the 
 <a rel="noopener noreferrer" target="_blank" href="https://github.com/opencybersecurityalliance/kestrel-lang">Kestrel</a> Threat Hunting Language and 
-<a rel="noopener noreferrer" target="_blank" href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=cacao">CACAO-based</a> automation.
+<a rel="noopener noreferrer" target="_blank" href="https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=b75cccb8-adc6-4de5-8b99-018dc7d322b6">CACAO-based</a> automation.
 </p>

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@ permalink: /
               <p>
                 OpenC2 is a standardized language for machine-to-machine communications for the command and control of
                 technologies that provide or support cyber defenses. The <a
-                  href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2">OpenC2 Technical
+                  href="https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296">OpenC2 Technical
                   Committee</a> is developing a suite of specifications that define the OpenC2 architecture, language,
                 tailor its use to specific cyber-defense functions, and specify how to convey OpenC2 messages using
                 various industry-standard transfer protocols.
@@ -189,14 +189,14 @@ permalink: /
                     Commands and Responses, and the mechanisms for extending the OpenC2 language.</p>
                 </li>
                 <li>
-                  <p><a href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2#technical"><strong>OpenC2
+                  <p><a href="https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296#technical"><strong>OpenC2
                         Actuator Profiles</strong></a> specify the subset of the OpenC2 language relevant in the context
                     of specific actuator functions (e.g., <a
                       href="https://docs.oasis-open.org/openc2/oc2slpf/v1.0/oc2slpf-v1.0.html">packet filtering</a>,
                     honeypots).</p>
                 </li>
                 <li>
-                  <p><a href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2#technical"><strong>OpenC2
+                  <p><a href="https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296#technical"><strong>OpenC2
                         Transfer Specifications</strong></a> utilize existing protocols and standards (e.g., <a
                       href="https://docs.oasis-open.org/openc2/open-impl-https/v1.1/cs01/open-impl-https-v1.1-cs01.html">HTTPS</a>,
                     <a href="https://docs.oasis-open.org/openc2/transf-mqtt/v1.0/transf-mqtt-v1.0.html">MQTT</a>) to
@@ -248,8 +248,8 @@ permalink: /
             <div id="faq-list-4" class="collapse" data-parent=".faq-list">
               <p>
                 OASIS Specifications are open for all to use. The TC's <a
-                  href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2">home page at OASIS</a> lists
-                the <a href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2#technical">officially
+                  href="https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296">home page at OASIS</a> lists
+                the <a href="https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296#technical">officially
                   published specifications</a>. This website includes a list of all <a
                   href="https://openc2.org/openc2-org.github.io/specifications.html">OpenC2 specifications (published
                   and under development)</a>, and a collection of <a

--- a/joinus.html
+++ b/joinus.html
@@ -13,7 +13,7 @@ permalink: /joinus.html
           Cyber security professionals involved in cyber-defense
           technology development and integration are <a
           rel="noopener noreferrer" target="_blank"
-          href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2">encouraged
+          href="https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296">encouraged
           to use</a> OpenC2 TC technical artifacts (e.g., the
           language specification and actuator profiles) when
           developing C2 capabilities for cyber-defense.
@@ -59,19 +59,19 @@ permalink: /joinus.html
         </p>
         <ul>
           <li><a rel="noopener noreferrer" target="_blank"
-          href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2-actuator">OpenC2
+          href="https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296-actuator">OpenC2
           Actuator Profile Subcommittee</a> - <em>Defining
           actuator profiles, the OpenC2 message elements
           applicable to specific cyber defense
           functions.</em></li>
           <li><a rel="noopener noreferrer" target="_blank"
-          href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2-imple">OpenC2
+          href="https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296-imple">OpenC2
           Implementation Considerations Subcommittee</a> -
           <em>Providing guidance for implementation aspects such
           as message transport and information
           assurance.</em></li>
           <li><a rel="noopener noreferrer" target="_blank"
-          href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2-lang">OpenC2
+          href="https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296-lang">OpenC2
           Language Subcommittee</a> - <em>Developing,
           maintaining, and resolving comments to the OpenC2
           language documentation.</em></li>

--- a/otc.html
+++ b/otc.html
@@ -11,7 +11,7 @@ permalink: /otc.html
       <div>
         <p>OpenC2 is a standardized language for the command and control of technologies that provide or support cyber defenses.</p>
         <p>The specifications and the standards for OpenC2 are developed in the
-           <a rel="noopener noreferrer" target="_blank" href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2">OASIS Open Command and Control (OpenC2) Technical Committee (TC)</a>.</p>
+           <a rel="noopener noreferrer" target="_blank" href="https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=a34c9baf-48b2-44c5-a567-018dc7d32296">OASIS Open Command and Control (OpenC2) Technical Committee (TC)</a>.</p>
         <p>The OpenC2 community consists of cybersecurity stakeholders across government agencies, small to large industries across all sectors, and academia.</p>
       </div>
     </div>


### PR DESCRIPTION
The PR updates links to the OASIS website (specifically the OpenC2 and CACAO TC pages) to match the new OASIS automation system deployed February 2024.