### PR TITLE
Fix FAQ links

### DIFF
--- a/_faqs/faq_144-Learn-JADN.md
+++ b/_faqs/faq_144-Learn-JADN.md
@@ -3,14 +3,13 @@ question: How can I learn more about JADN?
 ---
 
 A brief introduction to JADN can be found in the [*JADN and
-OpenC2*](JADN-and-OpenC2.md) document in the TC's [operations
+OpenC2*]([JADN-and-OpenC2.md](https://github.com/oasis-tcs/openc2-tc-ops/blob/main/JADN-and-OpenC2.md)) document in the TC's [operations
 repository](https://github.com/oasis-tcs/openc2-tc-ops). The TC
-is developing a [Committee Note
+has also developed a [Committee Note
 (CN)](https://www.oasis-open.org/policies-guidelines/oasis-defined-terms-2018-05-22/#dCommitteeNote)
 on [*Information Modeling Using
-JADN*](https://github.com/oasis-tcs/openc2-jadn-im/blob/working/imjadn-v1.0-cn01.md)
-(the link is to the in-progress draft, which is substantially
-complete). The CN provides an overview of information modeling
+JADN*](https://docs.oasis-open.org/openc2/imjadn/v1.0/imjadn-v1.0.html).
+The CN provides an overview of information modeling
 and the use of JADN for that purpose. Detailed specifics can be
 found in the [*Specification for JSON Abstract Data Notation
 (JADN)*](https://docs.oasis-open.org/openc2/jadn/v1.0/cs01/jadn-v1.0-cs01.html),

--- a/_faqs/faq_144-Learn-JADN.md
+++ b/_faqs/faq_144-Learn-JADN.md
@@ -3,7 +3,7 @@ question: How can I learn more about JADN?
 ---
 
 A brief introduction to JADN can be found in the [*JADN and
-OpenC2*]([JADN-and-OpenC2.md](https://github.com/oasis-tcs/openc2-tc-ops/blob/main/JADN-and-OpenC2.md)) document in the TC's [operations
+OpenC2*](https://github.com/oasis-tcs/openc2-tc-ops/blob/main/JADN-and-OpenC2.md) document in the TC's [operations
 repository](https://github.com/oasis-tcs/openc2-tc-ops). The TC
 has also developed a [Committee Note
 (CN)](https://www.oasis-open.org/policies-guidelines/oasis-defined-terms-2018-05-22/#dCommitteeNote)

--- a/_faqs/faq_190-Mtg-Schedule.md
+++ b/_faqs/faq_190-Mtg-Schedule.md
@@ -6,7 +6,7 @@ The OpenC2 TC holds meetings on Wednesdays at 11:00am Eastern
 Time ("OpenC2 Time"). The TC conducts business meetings on the
 3rd Wednesday of the month, and working meetings on the 1st, 2nd,
 and 4th Wednesdays of each month.  See the [Meeting
-Schedule](#https://github.com/oasis-tcs/openc2-tc-ops/blob/main/General-Member-Info.md#meeting-schedules)
+Schedule](https://github.com/oasis-tcs/openc2-tc-ops/blob/main/General-Member-Info.md#meeting-schedules)
 portion of the [General Member
 Information](https://github.com/oasis-tcs/openc2-tc-ops/blob/main/General-Member-Info.md)
 page of our [TC Operations


### PR DESCRIPTION
This update fixes broken links in the FAQs for more information about JADN and the TC's meeting schedule.