### PR TITLE
Update contacts page due to platform transition

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -24,8 +24,8 @@ permalink: /contact.html
           <div class="col-md-6 mt-4 mt-lg-0">
             <div class="icon-box">
               <i class="icofont-users"></i>
-              <h4><a href="mailto:openc2-chair@lists.oasis-open.org">TC cohairs</a></h4>
-              <p>openc2-chair@lists.oasis-open.org</p>
+              <h4><a href="">TC cohairs</a></h4>
+              <p>The TC Chairs mail list is temporarily unavailable during the OASIS community platform transition.</p>
             </div>
           </div>
         </div>
@@ -39,15 +39,15 @@ permalink: /contact.html
         <div class="col-md-6">
           <div class="icon-box">
             <i class="icofont-computer"></i>
-            <h4><a href="mailto:openc2-comment@lists.oasis-open.org">Post Comments about Technical work on TC</a></h4>
-            <p>openc2-comment@lists.oasis-open.org</p>
+            <h4><a href="">Post Comments about Technical work on TC</a></h4>
+            <p>The Comments mail list is temporarily unavailable during the OASIS community platform transition.</p>
           </div>
         </div>
         <div class="col-md-6 mt-4 mt-lg-0">
           <div class="icon-box">
             <i class="icofont-card"></i>
-            <h4><a href="mailto:member-services@oasis-open.org">Join OASIS or Contact Member Services</a></h4>
-            <p>member-services@oasis-open.org</p>
+            <h4><a href="https://www.oasis-open.org/join-2/">Join OASIS or Contact Member Services</a></h4>
+            <p>For information about participation in OASIS visit their <a href="https://www.oasis-open.org/join-2/" target="_blank">Get Involved</a> page.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
note that comments and chairs lists are unavailable

update OASIS involvement to a web page vs. the member services email address.