### PR TITLE
add CACAO extension to Specifications page

### DIFF
--- a/specifications.html
+++ b/specifications.html
@@ -98,6 +98,10 @@ permalink: /specifications.html
               <li><a rel="noopener noreferrer" target="_blank" href="https://github.com/oasis-tcs/openc2-transf-mqtt">OpenC2 MQTT transfer specification</a></li>
               <li><a rel="noopener noreferrer" target="_blank" href="https://github.com/oasis-tcs/openc2-transf-odxl">OpenC2 OpenDXL transfer specification</a></li>  
             </ul>
+            <li><b>Other Specifications</b></li>
+            <ul>
+              <li><a rel="noopener noreferrer" target="_blank" href="https://github.com/oasis-tcs/openc2-cacao-ext">OpenC2 Extension for CACAO</a></li>
+            </ul>
             <li><b>TC Operations-related Repositories</b></li>
             <ul>
               <li><a rel="noopener noreferrer" target="_blank" href="https://github.com/oasis-tcs/openc2-tc-ops">Documentation associated with TC operations</a></li>


### PR DESCRIPTION
Added under a new category of "Other Specifications", as this doesn't fit within our existing categories