### PR TITLE
update PF AP working version date info

### DIFF
--- a/pub-histories/pf-hist-table.md
+++ b/pub-histories/pf-hist-table.md
@@ -1,4 +1,4 @@
 | **Version** |                       **Approval Level**                      | **Publication Date** |
 |:-----------:|:-------------------------------------------------------------:|:--------------------:|
-|   v1.0 WIP  | <a rel="noopener noreferrer" target="_blank" href="https://github.com/oasis-tcs/openc2-ap-pf/tree/working/">Working Meeting: 8 Septenber 2021</a> |   8 September 2021   |
+|   v1.0 WIP  | <a rel="noopener noreferrer" target="_blank" href="https://github.com/oasis-tcs/openc2-ap-pf/tree/working/">Working Meeting: 7 August 2024</a> |   7 August 2024   |
 |     v1.0    | <a rel="noopener noreferrer" target="_blank" href="https://docs.oasis-open.org/openc2/ap-pf/v1.0/csd01/ap-pf-v1.0-csd01.html">CSD 01</a> |     21 July 2021     |


### PR DESCRIPTION
latest PF AP working draft is based on 7 Aug 2024 working meeting results; updating the data info accordingly.