### PR TITLE
Improve Publication History scrolling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -996,16 +996,3 @@ body {
   line-height: 1.5;
 }
 
-/* ============== EXPERIMENTAL============== */
-/* Add styles to adjust for the fixed header */ 
-/* This fixes ToC jumps to show doc titles   */
-/* source: https://www.geeksforgeeks.org/how-to-set-offset-an-html-anchor-element-to-adjust-fixed-header-in-css/, option 1  */ 
-   #target-element { 
-    display: block; 
-    position: relative; 
-    top: -80px; 
-      
-    /* Replace with the height of your fixed header */ 
-    visibility: hidden; 
-} 
-

--- a/pubhist.html
+++ b/pubhist.html
@@ -5,6 +5,41 @@ pageHeading: Publication History
 permalink: /pubhist.html
 ---
 
+<script>
+
+// experiment to compensate for page header when jumping to anchors
+// code from https://www.geeksforgeeks.org/offsetting-an-anchor-to-adjust-for-fixed-header/?ref=gcse_ind
+// this is their option 2 for address this visual glitch
+
+  // Get the header element
+  let header = document.querySelector('header');
+
+  // Get the height of the header
+  let headerHeight = header.offsetHeight;
+  document.querySelectorAll('a[href^="#"]')
+  .forEach(function (anchor) {
+      anchor.addEventListener('click', 
+      function (event) {
+          event.preventDefault();
+
+          // Get the target element that 
+          // the anchor link points to
+          let target = document.querySelector(
+              this.getAttribute('href')
+          );
+          
+          let targetPosition = target
+              .getBoundingClientRect().top - headerHeight;
+
+          window.scrollTo({
+              top: targetPosition + window.pageYOffset,
+              behavior: 'smooth'
+          });
+      });
+  });
+</script>
+
+
 <main id="main">
   <section>
     <div class="container" id="introduction">

--- a/pubhist.html
+++ b/pubhist.html
@@ -5,40 +5,6 @@ pageHeading: Publication History
 permalink: /pubhist.html
 ---
 
-<script>
-
-// experiment to compensate for page header when jumping to anchors
-// code from https://www.geeksforgeeks.org/offsetting-an-anchor-to-adjust-for-fixed-header/?ref=gcse_ind
-// this is their option 2 for address this visual glitch
-
-  // Get the header element
-  let header = document.querySelector('header');
-
-  // Get the height of the header
-  let headerHeight = header.offsetHeight;
-  document.querySelectorAll('a[href^="#"]')
-  .forEach(function (anchor) {
-      anchor.addEventListener('click', 
-      function (event) {
-          event.preventDefault();
-
-          // Get the target element that 
-          // the anchor link points to
-          let target = document.querySelector(
-              this.getAttribute('href')
-          );
-          
-          let targetPosition = target
-              .getBoundingClientRect().top - headerHeight;
-
-          window.scrollTo({
-              top: targetPosition + window.pageYOffset,
-              behavior: 'smooth'
-          });
-      });
-  });
-</script>
-
 
 <main id="main">
   <section>
@@ -426,3 +392,39 @@ permalink: /pubhist.html
     </div>
   </section>
 </main>
+
+<script>
+
+  // experiment to compensate for page header when jumping to anchors
+  // code from https://www.geeksforgeeks.org/offsetting-an-anchor-to-adjust-for-fixed-header/?ref=gcse_ind
+  // this is their option 2 for addressing this visual glitch
+  
+    // Get the header element
+    let header = document.querySelector('header');
+  
+    // Get the height of the header
+    let headerHeight = header.offsetHeight;
+    document.querySelectorAll('a[href^="#"]')
+    .forEach(function (anchor) {
+        anchor.addEventListener('click', 
+        function (event) {
+            event.preventDefault();
+  
+            // Get the target element that 
+            // the anchor link points to
+            let target = document.querySelector(
+                this.getAttribute('href')
+            );
+            
+            let targetPosition = target
+                .getBoundingClientRect().top - headerHeight;
+  
+            window.scrollTo({
+                top: targetPosition + window.pageYOffset,
+                behavior: 'smooth'
+            });
+        });
+    });
+  </script>
+  
+  


### PR DESCRIPTION
Add a script to the Publication History page (pubhist.html) to compensate for the fixed header. This ensures the document title appears when a document is selected from the table at the top.

This is pages on Approach 1 from this [Geeks for Geeks page](https://www.geeksforgeeks.org/offsetting-an-anchor-to-adjust-for-fixed-header/?ref=gcse_ind).