### PR TITLE
Update specs page links to OASIS latest vrsn link

### DIFF
--- a/specifications.html
+++ b/specifications.html
@@ -18,34 +18,34 @@ permalink: /specifications.html
       <ul>
         <li>
           <a rel="noopener noreferrer" target="_blank"
-            href="https://docs.oasis-open.org/openc2/oc2arch/v1.0/cs01/oc2arch-v1.0-cs01.html">Open Command and Control
+            href="https://docs.oasis-open.org/openc2/oc2arch/v1.0/oc2arch-v1.0.html">Open Command and Control
             (OpenC2) Architecture Specification Version 1.0</a>
         </li>
         <li>
           <a rel="noopener noreferrer" target="_blank"
-            href="https://docs.oasis-open.org/openc2/oc2ls/v1.0/cs02/oc2ls-v1.0-cs02.html">Open Command and Control
+            href="https://docs.oasis-open.org/openc2/oc2ls/v1.0/oc2ls-v1.0.html">Open Command and Control
             (OpenC2) Language Specification Version 1.0</a>
         </li>
         <li>
           <a rel="noopener noreferrer" target="_blank"
-            href="https://docs.oasis-open.org/openc2/oc2slpf/v1.0/cs01/oc2slpf-v1.0-cs01.html">Open Command and
+            href="https://docs.oasis-open.org/openc2/oc2slpf/v1.0/oc2slpf-v1.0.html">Open Command and
             Control (OpenC2) Profile for Stateless Packet Filtering (SLPF) Version 1.0
           </a>
         </li>
         <li>
           <a rel="noopener noreferrer" target="_blank"
-            href="https://docs.oasis-open.org/openc2/open-impl-https/v1.1/cs01/open-impl-https-v1.1-cs01.html">Specification
+            href="https://docs.oasis-open.org/openc2/open-impl-https/v1.1/open-impl-https-v1.1.html">Specification
             for Transfer of OpenC2 Messages via HTTPS Version 1.1</a> (replaces July 2019 v1.0)
         </li>
         <li>
           <a rel="noopener noreferrer" target="_blank"
-            href="https://docs.oasis-open.org/openc2/transf-mqtt/v1.0/cs01/transf-mqtt-v1.0-cs01.html">Specification
+            href="https://docs.oasis-open.org/openc2/transf-mqtt/v1.0/transf-mqtt-v1.0.html">Specification
             for Transfer of OpenC2 Messages via MQTT Version 1.0
           </a>
         </li>
         <li>
           <a rel="noopener noreferrer" target="_blank"
-            href="https://docs.oasis-open.org/openc2/jadn/v1.0/cs01/jadn-v1.0-cs01.html">JSON Abstract Data Notation (JADN) Version 1.0</a>
+            href="https://docs.oasis-open.org/openc2/jadn/v1.0/jadn-v1.0.html">JSON Abstract Data Notation (JADN) Version 1.0</a>
         </li>
         <li>
           <a rel="noopener noreferrer" target="_blank"
@@ -53,7 +53,7 @@ permalink: /specifications.html
         </li>
         <li>
           <a rel="noopener noreferrer" target="_blank"
-            href="https://docs.oasis-open.org/openc2/cn-appdev/v1.0/cn01/cn-appdev-v1.0-cn01.html">OpenC2 Actuator Profile Development Process Version 1.0 
+            href="https://docs.oasis-open.org/openc2/cn-appdev/v1.0/cn-appdev-v1.0.html">OpenC2 Actuator Profile Development Process Version 1.0 
            (CN01)</a>
         </li>
       </ul>


### PR DESCRIPTION
The specifications page was linking to specific CSxx / CNyy versions. This PR replaces those with the "latest version" links