### PR TITLE
Contact page updates

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -10,22 +10,22 @@ permalink: /contact.html
     <div class="container">
       <div class="section-title">
         <h2>OpenC2 Members</h2>
-        <p class="section-subtitle"><i>OpenC2 TC members may post to any of the OpenC2 discussion lists. OpenC2 TC membership is required to send to any of these lists.</i></p>
+        <p class="section-subtitle"><i>OpenC2 TC membership is required to send to any of these lists.</i></p>
       </div>
 
       <div class="row">
           <div class="col-md-6">
             <div class="icon-box">
               <i class="icofont-badge"></i>
-              <h4><a href="mailto:OASIS-openc2@ConnectedCommunity.org" target="_blank">Technical Committee Discussion List</a></h4>
-              <p>OASIS-openc2@ConnectedCommunity.org</p>
+              <h4>OpenC2<a href="mailto:OASIS-openc2@ConnectedCommunity.org" target="_blank">Technical Committee Discussion List</a></h4>
+              <p>TC members can post to the <a href="https://groups.oasis-open.org/communities/community-home/digestviewer?communitykey=a34c9baf-48b2-44c5-a567-018dc7d32296" target="_blank">OpenC2 TC discussion list</a>. This list is also publicly viewable.</p>
             </div>
           </div>
         </div>
       <br><br>
       <div class="section-title">
         <h2>Non Members and General Information</h2>
-        <p class="section-subtitle"><i>All Members and Non Members can request information using these lists.</i></p>
+        <p class="section-subtitle"><i>All Members and non-members can request information using these lists.</i></p>
       </div>
 
       <div class="row">

--- a/contact.html
+++ b/contact.html
@@ -17,7 +17,7 @@ permalink: /contact.html
           <div class="col-md-6">
             <div class="icon-box">
               <i class="icofont-badge"></i>
-              <h4>OpenC2<a href="mailto:OASIS-openc2@ConnectedCommunity.org" target="_blank">Technical Committee Discussion List</a></h4>
+              <h4>OpenC2 <a href="mailto:OASIS-openc2@ConnectedCommunity.org" target="_blank">Technical Committee Discussion List</a></h4>
               <p>TC members can post to the <a href="https://groups.oasis-open.org/communities/community-home/digestviewer?communitykey=a34c9baf-48b2-44c5-a567-018dc7d32296" target="_blank">OpenC2 TC discussion list</a>.</p>
             </div>
           </div>

--- a/contact.html
+++ b/contact.html
@@ -10,22 +10,15 @@ permalink: /contact.html
     <div class="container">
       <div class="section-title">
         <h2>OpenC2 Members</h2>
-        <p class="section-subtitle"><i>OpenC2 TC members may post to any of the OpenC2 mailing lists. OpenC2 TC membership is required to send to any of these lists.</i></p>
+        <p class="section-subtitle"><i>OpenC2 TC members may post to any of the OpenC2 discussion lists. OpenC2 TC membership is required to send to any of these lists.</i></p>
       </div>
 
       <div class="row">
           <div class="col-md-6">
             <div class="icon-box">
               <i class="icofont-badge"></i>
-              <h4><a href="mailto:OASIS-openc2@ConnectedCommunity.org">Technical Committee</a></h4>
+              <h4><a href="mailto:OASIS-openc2@ConnectedCommunity.org" target="_blank">Technical Committee Discussion List</a></h4>
               <p>OASIS-openc2@ConnectedCommunity.org</p>
-            </div>
-          </div>
-          <div class="col-md-6 mt-4 mt-lg-0">
-            <div class="icon-box">
-              <i class="icofont-users"></i>
-              <h4><a href="">TC cohairs</a></h4>
-              <p>The TC Chairs mail list is temporarily unavailable during the OASIS community platform transition.</p>
             </div>
           </div>
         </div>
@@ -39,8 +32,8 @@ permalink: /contact.html
         <div class="col-md-6">
           <div class="icon-box">
             <i class="icofont-computer"></i>
-            <h4><a href="">Post Comments about Technical work on TC</a></h4>
-            <p>The Comments mail list is temporarily unavailable during the OASIS community platform transition.</p>
+            <h4><a href="">Post comments about OpenC2 TC technical work</a></h4>
+            <p>Non-members can contribute comments on OpenC2 TC work products using the <a href="https://groups.oasis-open.org/communities/community-home?CommunityKey=9ae0f0f9-24b5-44ea-9fe7-018dce260e09" target="_blank">openc2-comment discussion list</a> (creation of an OASIS community platform account is required).</p>
           </div>
         </div>
         <div class="col-md-6 mt-4 mt-lg-0">
@@ -52,7 +45,7 @@ permalink: /contact.html
         </div>
       </div>
       <p></p><br>
-      <p>All mail is <a rel="noopener noreferrer" target="_blank" href="https://lists.oasis-open.org/archives/">archived publicly</a> and available for anyone to read.</p>
+      <p>Both the TC and comment discussion lists include all content since the founding of the OpenC2 TC in June 2017.</p>
     </div>
   </section>
 </main>

--- a/contact.html
+++ b/contact.html
@@ -18,7 +18,7 @@ permalink: /contact.html
             <div class="icon-box">
               <i class="icofont-badge"></i>
               <h4>OpenC2<a href="mailto:OASIS-openc2@ConnectedCommunity.org" target="_blank">Technical Committee Discussion List</a></h4>
-              <p>TC members can post to the <a href="https://groups.oasis-open.org/communities/community-home/digestviewer?communitykey=a34c9baf-48b2-44c5-a567-018dc7d32296" target="_blank">OpenC2 TC discussion list</a>. This list is also publicly viewable.</p>
+              <p>TC members can post to the <a href="https://groups.oasis-open.org/communities/community-home/digestviewer?communitykey=a34c9baf-48b2-44c5-a567-018dc7d32296" target="_blank">OpenC2 TC discussion list</a>.</p>
             </div>
           </div>
         </div>
@@ -45,7 +45,7 @@ permalink: /contact.html
         </div>
       </div>
       <p></p><br>
-      <p>Both the TC and comment discussion lists include all content since the founding of the OpenC2 TC in June 2017.</p>
+      <p>Both the TC and comment discussion lists are publicly viewable and include all content since the founding of the OpenC2 TC in June 2017.</p>
     </div>
   </section>
 </main>

--- a/contact.html
+++ b/contact.html
@@ -45,7 +45,7 @@ permalink: /contact.html
         </div>
       </div>
       <p></p><br>
-      <p>Both the TC and comment discussion lists are publicly viewable and include all content since the founding of the OpenC2 TC in June 2017.</p>
+      <p class="section-subtitle">Both the TC and comment discussion lists are publicly viewable and include all content since the founding of the OpenC2 TC in June 2017.</p>
     </div>
   </section>
 </main>


### PR DESCRIPTION
Update links and descriptions to align with OASIS community platform organization. Remove obsolete TC Chairs mail list link and description.